### PR TITLE
SCIM patch converter array removal fixes

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -18,7 +18,7 @@ jacksonVersion = "2.15.3"
 jacksonDatabindVersion = "2.13.4+2"
 testngVersion = "7.3.0"
 
-project(group: "io.fusionauth", name: "fusionauth-scim", version: "2.2.1", licenses: ["ApacheV2_0"]) {
+project(group: "io.fusionauth", name: "fusionauth-scim", version: "2.2.2", licenses: ["ApacheV2_0"]) {
   workflow {
     fetch {
       cache()

--- a/fusionauth-scim.iml
+++ b/fusionauth-scim.iml
@@ -14,62 +14,62 @@
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$USER_HOME$/.savant/cache/com/fasterxml/jackson/core/jackson-databind/2.13.3/jackson-databind-2.13.3.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/com/fasterxml/jackson/core/jackson-databind/2.13.4+2/jackson-databind-2.13.4+2.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$USER_HOME$/.savant/cache/com/fasterxml/jackson/core/jackson-databind/2.13.3/jackson-databind-2.13.3-src.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/com/fasterxml/jackson/core/jackson-databind/2.13.4+2/jackson-databind-2.13.4+2-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$USER_HOME$/.savant/cache/com/fasterxml/jackson/core/jackson-annotations/2.13.3/jackson-annotations-2.13.3.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/com/fasterxml/jackson/core/jackson-annotations/2.15.3/jackson-annotations-2.15.3.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$USER_HOME$/.savant/cache/com/fasterxml/jackson/core/jackson-annotations/2.13.3/jackson-annotations-2.13.3-src.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/com/fasterxml/jackson/core/jackson-annotations/2.15.3/jackson-annotations-2.15.3-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$USER_HOME$/.savant/cache/com/fasterxml/jackson/core/jackson-core/2.13.3/jackson-core-2.13.3.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/com/fasterxml/jackson/core/jackson-core/2.15.3/jackson-core-2.15.3.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$USER_HOME$/.savant/cache/com/fasterxml/jackson/core/jackson-core/2.13.3/jackson-core-2.13.3-src.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/com/fasterxml/jackson/core/jackson-core/2.15.3/jackson-core-2.15.3-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library" scope="TEST">
       <library>
         <CLASSES>
-          <root url="jar://$USER_HOME$/.savant/cache/org/testng/testng/7.3.0/testng-7.3.0.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/testng/testng/7.3.0/testng-7.3.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$USER_HOME$/.savant/cache/org/testng/testng/7.3.0/testng-7.3.0-src.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/testng/testng/7.3.0/testng-7.3.0-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library" scope="TEST">
       <library>
         <CLASSES>
-          <root url="jar://$USER_HOME$/.savant/cache/com/beust/jcommander/1.78.0/jcommander-1.78.0.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/com/beust/jcommander/1.78.0/jcommander-1.78.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$USER_HOME$/.savant/cache/com/beust/jcommander/1.78.0/jcommander-1.78.0-src.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/com/beust/jcommander/1.78.0/jcommander-1.78.0-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library" scope="TEST">
       <library>
         <CLASSES>
-          <root url="jar://$USER_HOME$/.savant/cache/com/google/inject/guice/4.2.2/guice-no_aop-4.2.2.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/com/google/inject/guice/4.2.2/guice-no_aop-4.2.2.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES />
@@ -78,143 +78,143 @@
     <orderEntry type="module-library" scope="TEST">
       <library>
         <CLASSES>
-          <root url="jar://$USER_HOME$/.savant/cache/javax/inject/javax.inject/1.0.0/javax.inject-1.0.0.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/javax/inject/javax.inject/1.0.0/javax.inject-1.0.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$USER_HOME$/.savant/cache/javax/inject/javax.inject/1.0.0/javax.inject-1.0.0-src.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/javax/inject/javax.inject/1.0.0/javax.inject-1.0.0-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library" scope="TEST">
       <library>
         <CLASSES>
-          <root url="jar://$USER_HOME$/.savant/cache/org/aopalliance/aopalliance/1.0.0/aopalliance-1.0.0.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/aopalliance/aopalliance/1.0.0/aopalliance-1.0.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$USER_HOME$/.savant/cache/org/aopalliance/aopalliance/1.0.0/aopalliance-1.0.0-src.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/aopalliance/aopalliance/1.0.0/aopalliance-1.0.0-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library" scope="TEST">
       <library>
         <CLASSES>
-          <root url="jar://$USER_HOME$/.savant/cache/com/google/guava/guava/25.1.0-android/guava-25.1.0-android.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/com/google/guava/guava/25.1.0-android/guava-25.1.0-android.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$USER_HOME$/.savant/cache/com/google/guava/guava/25.1.0-android/guava-25.1.0-android-src.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/com/google/guava/guava/25.1.0-android/guava-25.1.0-android-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library" scope="TEST">
       <library>
         <CLASSES>
-          <root url="jar://$USER_HOME$/.savant/cache/org/checkerframework/checker-compat-qual/2.0.0/checker-compat-qual-2.0.0.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/checkerframework/checker-compat-qual/2.0.0/checker-compat-qual-2.0.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$USER_HOME$/.savant/cache/org/checkerframework/checker-compat-qual/2.0.0/checker-compat-qual-2.0.0-src.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/checkerframework/checker-compat-qual/2.0.0/checker-compat-qual-2.0.0-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library" scope="TEST">
       <library>
         <CLASSES>
-          <root url="jar://$USER_HOME$/.savant/cache/com/google/j2objc/j2objc-annotations/1.1.0/j2objc-annotations-1.1.0.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/com/google/j2objc/j2objc-annotations/1.1.0/j2objc-annotations-1.1.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$USER_HOME$/.savant/cache/com/google/j2objc/j2objc-annotations/1.1.0/j2objc-annotations-1.1.0-src.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/com/google/j2objc/j2objc-annotations/1.1.0/j2objc-annotations-1.1.0-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library" scope="TEST">
       <library>
         <CLASSES>
-          <root url="jar://$USER_HOME$/.savant/cache/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$USER_HOME$/.savant/cache/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2-src.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library" scope="TEST">
       <library>
         <CLASSES>
-          <root url="jar://$USER_HOME$/.savant/cache/com/google/errorprone/error_prone_annotations/2.1.3/error_prone_annotations-2.1.3.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/com/google/errorprone/error_prone_annotations/2.1.3/error_prone_annotations-2.1.3.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$USER_HOME$/.savant/cache/com/google/errorprone/error_prone_annotations/2.1.3/error_prone_annotations-2.1.3-src.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/com/google/errorprone/error_prone_annotations/2.1.3/error_prone_annotations-2.1.3-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library" scope="TEST">
       <library>
         <CLASSES>
-          <root url="jar://$USER_HOME$/.savant/cache/org/codehaus/mojo/animal-sniffer-annotations/1.14.0/animal-sniffer-annotations-1.14.0.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/codehaus/mojo/animal-sniffer-annotations/1.14.0/animal-sniffer-annotations-1.14.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$USER_HOME$/.savant/cache/org/codehaus/mojo/animal-sniffer-annotations/1.14.0/animal-sniffer-annotations-1.14.0-src.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/codehaus/mojo/animal-sniffer-annotations/1.14.0/animal-sniffer-annotations-1.14.0-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library" scope="TEST">
       <library>
         <CLASSES>
-          <root url="jar://$USER_HOME$/.savant/cache/org/yaml/snakeyaml/1.21.0/snakeyaml-1.21.0.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/yaml/snakeyaml/1.21.0/snakeyaml-1.21.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$USER_HOME$/.savant/cache/org/yaml/snakeyaml/1.21.0/snakeyaml-1.21.0-src.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/yaml/snakeyaml/1.21.0/snakeyaml-1.21.0-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library" scope="TEST">
       <library>
         <CLASSES>
-          <root url="jar://$USER_HOME$/.savant/cache/org/junit/junit/4.12.0/junit-4.12.0.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/junit/junit/4.12.0/junit-4.12.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$USER_HOME$/.savant/cache/org/junit/junit/4.12.0/junit-4.12.0-src.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/junit/junit/4.12.0/junit-4.12.0-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library" scope="TEST">
       <library>
         <CLASSES>
-          <root url="jar://$USER_HOME$/.savant/cache/org/hamcrest/hamcrest-core/1.3.0/hamcrest-core-1.3.0.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/hamcrest/hamcrest-core/1.3.0/hamcrest-core-1.3.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$USER_HOME$/.savant/cache/org/hamcrest/hamcrest-core/1.3.0/hamcrest-core-1.3.0-src.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/hamcrest/hamcrest-core/1.3.0/hamcrest-core-1.3.0-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library" scope="TEST">
       <library>
         <CLASSES>
-          <root url="jar://$USER_HOME$/.savant/cache/org/apache/ant/ant/1.10.3/ant-1.10.3.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/apache/ant/ant/1.10.3/ant-1.10.3.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$USER_HOME$/.savant/cache/org/apache/ant/ant/1.10.3/ant-1.10.3-src.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/apache/ant/ant/1.10.3/ant-1.10.3-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library" scope="TEST">
       <library>
         <CLASSES>
-          <root url="jar://$USER_HOME$/.savant/cache/org/apache/ant/ant-launcher/1.10.3/ant-launcher-1.10.3.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/apache/ant/ant-launcher/1.10.3/ant-launcher-1.10.3.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$USER_HOME$/.savant/cache/org/apache/ant/ant-launcher/1.10.3/ant-launcher-1.10.3-src.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/apache/ant/ant-launcher/1.10.3/ant-launcher-1.10.3-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>

--- a/src/main/java/io/fusionauth/scim/utils/SCIMPatchTools.java
+++ b/src/main/java/io/fusionauth/scim/utils/SCIMPatchTools.java
@@ -210,8 +210,8 @@ public class SCIMPatchTools {
       arrayRemoveOps.sort(
           (o1, o2) -> {
             // Sort by path and then descending index
-            Integer path1 = o1.at("/value").get(0).asInt();
-            Integer path2 = o2.at("/value").get(0).asInt();
+            String path1 = o1.at("/value").get(0).asText();
+            String path2 = o2.at("/value").get(0).asText();
             int pathComparison = path1.compareTo(path2);
             if (pathComparison != 0) {
               return pathComparison;

--- a/src/main/java/io/fusionauth/scim/utils/SCIMPatchTools.java
+++ b/src/main/java/io/fusionauth/scim/utils/SCIMPatchTools.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, FusionAuth, All Rights Reserved
+ * Copyright (c) 2022-2024, FusionAuth, All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package io.fusionauth.scim.utils;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -23,6 +24,7 @@ import java.util.regex.Pattern;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.IntNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
@@ -162,6 +164,7 @@ public class SCIMPatchTools {
 
     // Take a second pass and check for remaining filter ops
     ArrayNode result2 = JsonNodeFactory.instance.arrayNode();
+    List<ObjectNode> arrayRemoveOps = new ArrayList<>();
 
     for (JsonNode operation : result) {
       JsonNode value = operation.at("/value");
@@ -172,7 +175,7 @@ public class SCIMPatchTools {
         JsonNode attributeNode = source.at(path.asText());
         if (attributeNode instanceof ArrayNode array) {
 
-          // Assume we have just a single value in the "value" node, assuming it will have to be an object to haev a named key.
+          // Assume we have just a single value in the "value" node, assuming it will have to be an object to have a named key.
           String attributePath = null;
           if (value instanceof ObjectNode objectNode) {
             attributePath = objectNode.fieldNames().next();
@@ -191,8 +194,9 @@ public class SCIMPatchTools {
               // - Add a new op to the result for each matching node. It is plausible we'll match more than one node.
               ObjectNode copy = operation.deepCopy();
               copy.set("path", TextNode.valueOf(path.asText() + "/" + i));
-              copy.remove("value");
-              result2.add(copy);
+              // Temporarily set the value for later sorting and add to list
+              copy.set("value", objectMapper.createArrayNode().add(TextNode.valueOf(path.asText())).add(IntNode.valueOf(i)));
+              arrayRemoveOps.add(copy);
             }
           }
         }
@@ -200,6 +204,29 @@ public class SCIMPatchTools {
         result2.add(operation);
       }
     }
+
+    // Sort array removal operations and add to the result
+    if (!arrayRemoveOps.isEmpty()) {
+      arrayRemoveOps.sort(
+          (o1, o2) -> {
+            // Sort by path and then descending index
+            Integer path1 = o1.at("/value").get(0).asInt();
+            Integer path2 = o2.at("/value").get(0).asInt();
+            int pathComparison = path1.compareTo(path2);
+            if (pathComparison != 0) {
+              return pathComparison;
+            }
+
+            Integer index1 = o1.at("/value").get(1).asInt();
+            Integer index2 = o2.at("/value").get(1).asInt();
+            return index1.compareTo(index2) * -1;
+          }
+      );
+      // Clear the value node after sorting
+      arrayRemoveOps.forEach(o -> o.remove("value"));
+    }
+
+    result2.addAll(arrayRemoveOps);
 
     return result2;
   }

--- a/src/test/json/json-patch/combined.json
+++ b/src/test/json/json-patch/combined.json
@@ -1,5 +1,9 @@
 [
   {
+    "op": "remove",
+    "path": "/emails/1/type"
+  },
+  {
     "op": "add",
     "path": "/members/-",
     "value": {
@@ -10,10 +14,6 @@
     "op": "replace",
     "path": "/displayName",
     "value": "Update the name"
-  },
-  {
-    "op": "remove",
-    "path": "/emails/1"
   },
   {
     "op": "remove",

--- a/src/test/json/json-patch/combined.json
+++ b/src/test/json/json-patch/combined.json
@@ -1,0 +1,38 @@
+[
+  {
+    "op": "add",
+    "path": "/members/-",
+    "value": {
+      "value": "13ec78d9-59e5-4c91-a2b6-be79fa2e2695"
+    }
+  },
+  {
+    "op": "replace",
+    "path": "/displayName",
+    "value": "Update the name"
+  },
+  {
+    "op": "remove",
+    "path": "/emails/1"
+  },
+  {
+    "op": "remove",
+    "path": "/emails/0"
+  },
+  {
+    "op": "remove",
+    "path": "/members/8"
+  },
+  {
+    "op": "remove",
+    "path": "/members/4"
+  },
+  {
+    "op": "remove",
+    "path": "/members/3"
+  },
+  {
+    "op": "remove",
+    "path": "/members/0"
+  }
+]

--- a/src/test/json/json-patch/remove_multiple_by_value.json
+++ b/src/test/json/json-patch/remove_multiple_by_value.json
@@ -1,0 +1,26 @@
+[
+  {
+    "op": "remove",
+    "path": "/emails/1"
+  },
+  {
+    "op": "remove",
+    "path": "/emails/0"
+  },
+  {
+    "op": "remove",
+    "path": "/members/8"
+  },
+  {
+    "op": "remove",
+    "path": "/members/4"
+  },
+  {
+    "op": "remove",
+    "path": "/members/3"
+  },
+  {
+    "op": "remove",
+    "path": "/members/0"
+  }
+]

--- a/src/test/json/resource.json
+++ b/src/test/json/resource.json
@@ -2,6 +2,33 @@
   "members": [
     {
       "value": "cbdf95c8-b3aa-42a4-8e29-09db32099b0a"
+    },
+    {
+      "value": "eb3d12fa-4038-403d-962e-61ac8cbf0057"
+    },
+    {
+      "value": "d6693a70-58ae-47a8-bc3c-eaa676693db5"
+    },
+    {
+      "value": "d80fe1f8-660d-4a6f-ae60-ace057ad3c23"
+    },
+    {
+      "value": "c4a4dcc6-fdfc-406e-9ddd-0946ac7dc1fe"
+    },
+    {
+      "value": "7ec2bba5-0f1a-4cc1-b5b3-4edf9a8afc53"
+    },
+    {
+      "value": "8013c997-073e-4bfd-b29b-c8f3c8dade6a"
+    },
+    {
+      "value": "56a74970-a4a3-468e-8302-98bc9d993cfd"
+    },
+    {
+      "value": "17dcd397-1684-494a-bda6-32c26ea6aebf"
+    },
+    {
+      "value": "12e92285-3967-43ea-b627-8bf42ecc8309"
     }
   ],
   "emails": [

--- a/src/test/json/scim-patch/combined.json
+++ b/src/test/json/scim-patch/combined.json
@@ -1,0 +1,58 @@
+{
+  "schemas": [
+    "urn:ietf:params:scim:api:messages:2.0:PatchOp"
+  ],
+  "Operations": [
+    {
+      "op": "Remove",
+      "path": "members",
+      "value": [
+        {
+          "value": "cbdf95c8-b3aa-42a4-8e29-09db32099b0a"
+        },
+        {
+          "value": "d80fe1f8-660d-4a6f-ae60-ace057ad3c23"
+        },
+        {
+          "value": "17dcd397-1684-494a-bda6-32c26ea6aebf"
+        }
+      ]
+    },
+    {
+      "op": "Remove",
+      "path": "members",
+      "value": [
+        {
+          "value": "c4a4dcc6-fdfc-406e-9ddd-0946ac7dc1fe"
+        }
+      ]
+    },
+    {
+      "op": "Add",
+      "path": "members",
+      "value": [
+        {
+          "value": "13ec78d9-59e5-4c91-a2b6-be79fa2e2695"
+        }
+      ]
+    },
+    {
+      "op": "Remove",
+      "path": "emails",
+      "value": [
+        {
+          "value": "erlich@bachmanity.com"
+        },
+        {
+          "value": "erlich@piedpiper.com"
+        }
+      ]
+    },
+    {
+      "op": "replace",
+      "value": {
+        "displayName": "Update the name"
+      }
+    }
+  ]
+}

--- a/src/test/json/scim-patch/combined.json
+++ b/src/test/json/scim-patch/combined.json
@@ -5,6 +5,10 @@
   "Operations": [
     {
       "op": "Remove",
+      "path": "/emails/1/type"
+    },
+    {
+      "op": "Remove",
       "path": "members",
       "value": [
         {
@@ -42,9 +46,6 @@
       "value": [
         {
           "value": "erlich@bachmanity.com"
-        },
-        {
-          "value": "erlich@piedpiper.com"
         }
       ]
     },

--- a/src/test/json/scim-patch/remove_multiple_by_value.json
+++ b/src/test/json/scim-patch/remove_multiple_by_value.json
@@ -1,0 +1,43 @@
+{
+  "schemas": [
+    "urn:ietf:params:scim:api:messages:2.0:PatchOp"
+  ],
+  "Operations": [
+    {
+      "op": "Remove",
+      "path": "members",
+      "value": [
+        {
+          "value": "cbdf95c8-b3aa-42a4-8e29-09db32099b0a"
+        },
+        {
+          "value": "d80fe1f8-660d-4a6f-ae60-ace057ad3c23"
+        },
+        {
+          "value": "17dcd397-1684-494a-bda6-32c26ea6aebf"
+        }
+      ]
+    },
+    {
+      "op": "Remove",
+      "path": "members",
+      "value": [
+        {
+          "value": "c4a4dcc6-fdfc-406e-9ddd-0946ac7dc1fe"
+        }
+      ]
+    },
+    {
+      "op": "Remove",
+      "path": "emails",
+      "value": [
+        {
+          "value": "erlich@bachmanity.com"
+        },
+        {
+          "value": "erlich@piedpiper.com"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adjust conversion from SCIM Patch to JSON Patch to sort `remove` array operations by descending index. Array removal operations are now placed at the end of the JSON patch. This prevents errors due to shifting array elements during deletion.
- https://github.com/FusionAuth/fusionauth-issues/issues/2834